### PR TITLE
Create initial repo with FAST API app and Celery tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # celery_testing
 Celery Testing
+
+## How to start this project
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/johnfawzy84/celery_testing.git
+   cd celery_testing
+   ```
+
+2. Install Poetry:
+   ```sh
+   curl -sSL https://install.python-poetry.org | python3 -
+   ```
+
+3. Install dependencies:
+   ```sh
+   poetry install
+   ```
+
+4. Activate the virtual environment:
+   ```sh
+   poetry shell
+   ```
+
+5. Start the services using Docker Compose:
+   ```sh
+   docker-compose up
+   ```
+
+6. Run the FastAPI application:
+   ```sh
+   uvicorn main:app --reload
+   ```
+
+7. Open your browser and go to `http://localhost:8000` to see the FastAPI application running.
+
+8. To run the tests:
+   ```sh
+   pytest
+   ```

--- a/celery.py
+++ b/celery.py
@@ -1,0 +1,6 @@
+from celery import Celery
+from celery_insight import Insight
+
+app = Celery('tasks', broker='redis://localhost:6379/0', backend='redis://localhost:6379/0')
+
+insight = Insight(app)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       - redis
       - celery_worker
+    networks:
+      - shared_network
 
   celery_worker:
     build:
@@ -22,6 +24,8 @@ services:
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
+    networks:
+      - shared_network
 
   celery_insight:
     image: celery-insight
@@ -34,9 +38,18 @@ services:
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
+    networks:
+      - shared_network
 
   redis:
     image: redis:6.0
     container_name: redis
     ports:
       - "6379:6379"
+    networks:
+      - shared_network
+
+networks:
+  default:
+    name: celery_testing_network
+  shared_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,13 @@ version: '3.8'
 
 services:
   fastapi:
-    image: tiangolo/uvicorn-gunicorn-fastapi:python3.8
+    build:
+      context: .
+      dockerfile: Dockerfile.fastapi
     container_name: fastapi
+    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
     ports:
-      - "8000:80"
+      - "8000:8000"
     volumes:
       - .:/app
     depends_on:
@@ -19,6 +22,7 @@ services:
       context: .
       dockerfile: Dockerfile.celery
     container_name: celery_worker
+    command: ["celery", "-A", "tasks", "worker", "--loglevel=info"]
     depends_on:
       - redis
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,15 @@ services:
     networks:
       - shared_network
 
+  flower:
+    image: mher/flower
+    container_name: flower
+    ports:
+      - "5555:5555"
+    command: ["flower", "--broker=redis://redis:6379/0"]
+    networks:
+      - shared_network
+
 networks:
   default:
     name: celery_testing_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  fastapi:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.8
+    container_name: fastapi
+    ports:
+      - "8000:80"
+    volumes:
+      - .:/app
+    depends_on:
+      - redis
+      - celery_worker
+
+  celery_worker:
+    build:
+      context: .
+      dockerfile: Dockerfile.celery
+    container_name: celery_worker
+    depends_on:
+      - redis
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+
+  celery_insight:
+    image: celery-insight
+    container_name: celery_insight
+    ports:
+      - "5555:5555"
+    depends_on:
+      - redis
+      - celery_worker
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+
+  redis:
+    image: redis:6.0
+    container_name: redis
+    ports:
+      - "6379:6379"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI, BackgroundTasks
+from uuid import UUID
+from tasks import add, subtract, chain
+
+app = FastAPI()
+
+@app.post("/tasks/add")
+async def add_task(x: int, y: int, background_tasks: BackgroundTasks):
+    task = add.apply_async(args=[x, y])
+    background_tasks.add_task(task.wait)
+    return {"task_id": task.id}
+
+@app.post("/tasks/subtract")
+async def subtract_task(x: int, y: int, background_tasks: BackgroundTasks):
+    task = subtract.apply_async(args=[x, y])
+    background_tasks.add_task(task.wait)
+    return {"task_id": task.id}
+
+@app.post("/tasks/chain")
+async def chain_task(tasks: list, background_tasks: BackgroundTasks):
+    task_chain = chain(*tasks)
+    task = task_chain.apply_async()
+    background_tasks.add_task(task.wait)
+    return {"task_id": task.id}
+
+@app.get("/tasks/{task_id}/status")
+async def get_task_status(task_id: UUID):
+    task = add.AsyncResult(str(task_id))
+    return {"task_id": task.id, "status": task.status}
+
+@app.get("/tasks/{task_id}/result")
+async def get_task_result(task_id: UUID):
+    task = add.AsyncResult(str(task_id))
+    if task.status == "SUCCESS":
+        return {"task_id": task.id, "result": task.result}
+    return {"task_id": task.id, "status": task.status}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.poetry]
+name = "celery_testing"
+version = "0.1.0"
+description = "A project to test Celery with FastAPI"
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+packages = [{include = "celery_testing"}]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+fastapi = "^0.68.0"
+celery = "^5.1.2"
+redis = "^3.5.3"
+celery-insight = "^0.1.0"
+pytest = "^6.2.4"
+pytest-celery = "^0.0.0"
+testcontainers = "^3.4.2"
+
+[tool.poetry.dev-dependencies]
+pytest = "^6.2.4"
+pytest-celery = "^0.0.0"
+testcontainers = "^3.4.2"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[virtualenvs]
+in-project = true

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,9 @@
+from .celery import app
+
+@app.task
+def add(x, y):
+    return x + y
+
+@app.task
+def subtract(x, y):
+    return x - y

--- a/tests/test_celery_tasks.py
+++ b/tests/test_celery_tasks.py
@@ -1,0 +1,33 @@
+import pytest
+from celery.contrib.pytest import celery_app, celery_worker
+from testcontainers.redis import RedisContainer
+from tasks import add, subtract
+
+@pytest.fixture(scope="module")
+def redis_container():
+    with RedisContainer() as redis:
+        yield redis
+
+@pytest.fixture(scope="module")
+def celery_config(redis_container):
+    return {
+        "broker_url": redis_container.get_connection_url(),
+        "result_backend": redis_container.get_connection_url(),
+    }
+
+@pytest.fixture(scope="module")
+def celery_includes():
+    return ["tasks"]
+
+def test_add_task(celery_app, celery_worker):
+    result = add.apply_async(args=[4, 6])
+    assert result.get(timeout=10) == 10
+
+def test_subtract_task(celery_app, celery_worker):
+    result = subtract.apply_async(args=[10, 4])
+    assert result.get(timeout=10) == 6
+
+def test_chain_tasks(celery_app, celery_worker):
+    from celery import chain
+    result = chain(add.s(4, 6), subtract.s(2)).apply_async()
+    assert result.get(timeout=10) == 8


### PR DESCRIPTION
Add initial implementation of FAST API app with Celery tasks for addition and subtraction.

* **main.py**: Create a FAST API app with endpoints for addition, subtraction, task chaining, task status, and task result.
* **tasks.py**: Define Celery tasks for addition and subtraction.
* **celery.py**: Configure Celery to use Redis as the broker and backend, and integrate `celery-insight`.
* **tests/test_celery_tasks.py**: Add unit tests for Celery tasks and chains using `celery.contrib.pytest` and `testcontainers`.
* **docker-compose.yml**: Define services for the FAST API app, Celery worker, Celery Insight, and Redis.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/johnfawzy84/celery_testing/pull/1?shareId=953c9a2f-fcd3-415c-85fb-ddd5ade0f333).